### PR TITLE
fix(ethers-v6): error caused by using 0x as address

### DIFF
--- a/packages/target-ethers-v6/src/codegen/reserved-keywords.ts
+++ b/packages/target-ethers-v6/src/codegen/reserved-keywords.ts
@@ -1,9 +1,9 @@
-import { BaseContract } from 'ethers'
+import { BaseContract, ZeroAddress } from 'ethers'
 
 export const ethersPassProperties = new Set(['then'])
 export const baseContractProperties = new Set([
   ...Object.getOwnPropertyNames(BaseContract.prototype), // for methods
-  ...Object.keys(new BaseContract('0x', [])), // for readOnly properties
+  ...Object.keys(new BaseContract(ZeroAddress, [])), // for readOnly properties
 ])
 
 export const reservedKeywordsLabels = new Set([


### PR DESCRIPTION
```
Error: provider is required to use ENS name as contract address
```